### PR TITLE
fix(index, saved_searches): Refreshing Terraform state if resources a…

### DIFF
--- a/splunk/resource_splunk_indexes.go
+++ b/splunk/resource_splunk_indexes.go
@@ -403,6 +403,13 @@ func indexRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if entry == nil {
+		if !d.IsNewResource() {
+			// This probably means someone has deleted the index from Splunk directly. Setting empty id here to
+			// force Terraform to delete resource from state and thereby recreating it
+			d.SetId("")
+
+			return nil
+		}
 		return fmt.Errorf("Unable to find resource: %s", name)
 	}
 

--- a/splunk/resource_splunk_indexes_test.go
+++ b/splunk/resource_splunk_indexes_test.go
@@ -38,6 +38,14 @@ func TestAccCreateSplunkIndex(t *testing.T) {
 				),
 			},
 			{
+				// to test re-creation of remotely deleted or missing resources, delete the new index before updating it
+				PreConfig: func() {
+					client, _ := newTestClient()
+
+					if _, err := client.DeleteIndexObject("new-index", "nobody", "system"); err != nil {
+						t.Error("PreConfig deletion of new-index failed")
+					}
+				},
 				Config: updateIndex,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "max_time_unreplicated_no_acks", "301"),

--- a/splunk/resource_splunk_saved_searches.go
+++ b/splunk/resource_splunk_saved_searches.go
@@ -58,9 +58,9 @@ func savedSearches() *schema.Resource {
 					"4 - Warning",
 			},
 			"action_snow_event_param_description": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 				Description: "	A brief description of the event.",
 			},
 			"action_snow_event_param_ci_identifier": {
@@ -1152,6 +1152,13 @@ func savedSearchesRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if entry == nil {
+		if !d.IsNewResource() {
+			// This probably means someone has deleted the saved search from Splunk directly. Setting empty id here to
+			// force Terraform to delete resource from state and thereby recreating it
+			d.SetId("")
+
+			return nil
+		}
 		return fmt.Errorf("Unable to find resource: %v", name)
 	}
 

--- a/splunk/resource_splunk_saved_searches_test.go
+++ b/splunk/resource_splunk_saved_searches_test.go
@@ -296,6 +296,14 @@ func TestAccSplunkSavedSearches(t *testing.T) {
 				),
 			},
 			{
+				// to test re-creation of remotely deleted or missing resources, delete the new saved serarch before updating it
+				PreConfig: func() {
+					client, _ := newTestClient()
+
+					if _, err := client.DeleteSavedSearches("Test New Alert", "nobody", "search"); err != nil {
+						t.Error("PreConfig deletion of Test New Alert failed")
+					}
+				},
 				Config: updatedSavedSearches,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "Test New Alert"),


### PR DESCRIPTION
…re deleted outside of Terraform

Instead of erroring out on Terraform plan / apply